### PR TITLE
Fix a NullPointerException when people specify a path in the same directory without a parent.

### DIFF
--- a/src/main/java/net/lax1dude/eaglercraft/bintools/OBJConverter.java
+++ b/src/main/java/net/lax1dude/eaglercraft/bintools/OBJConverter.java
@@ -50,9 +50,10 @@ public class OBJConverter {
 		System.out.println("Exporting " + (v1_8 ? "1.8" : "1.5") + " MDL: " + output.getAbsolutePath());
 		boolean tex = args[2].equalsIgnoreCase("true") || args[2].equals("1");
 		if (!output.exists()) {
-			if (!output.getParentFile().exists())
-				if (!output.getParentFile().mkdirs())
-					throw new RuntimeException("Failed to create parent dir!");
+			if (output.getParentFile() != null)
+				if (!output.getParentFile().exists())
+					if (!output.getParentFile().mkdirs())
+						throw new RuntimeException("Failed to create parent dir!");
 			if (!output.createNewFile())
 				throw new RuntimeException("Failed to create file!");
 		}

--- a/src/main/java/net/lax1dude/eaglercraft/bintools/OptimizedOBJConverter.java
+++ b/src/main/java/net/lax1dude/eaglercraft/bintools/OptimizedOBJConverter.java
@@ -25,9 +25,10 @@ public class OptimizedOBJConverter {
 		System.out.println("Exporting " + (v1_8 ? "1.8" : "1.5") + " MDL: " + output.getAbsolutePath());
 		boolean tex = args[2].equalsIgnoreCase("true") || args[2].equals("1");
 		if (!output.exists()) {
-			if (!output.getParentFile().exists())
-				if (!output.getParentFile().mkdirs())
-					throw new RuntimeException("Failed to create parent dir!");
+			if (output.getParentFile() != null)
+				if (!output.getParentFile().exists())
+					if (!output.getParentFile().mkdirs())
+						throw new RuntimeException("Failed to create parent dir!");
 			if (!output.createNewFile())
 				throw new RuntimeException("Failed to create file!");
 		}


### PR DESCRIPTION
Fix a NullPointerException caused by specifying an output file without a parent directory.